### PR TITLE
Handle promise failures better

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,6 @@ module.exports = function (params) {
                     copyFile(target[i], dest, function (vnl, pos) {
                         partial.fragments[pos] = vnl.contents;
                         partial.length += vnl.contents.length;
-
                         resolve();
                     }, i);
                 }));
@@ -108,6 +107,8 @@ module.exports = function (params) {
                     callback.call(null, compiled);
 
                     resolve();
+                }).catch(function(error) {
+                    reject(error);
                 });
             }));
         } else {
@@ -158,9 +159,12 @@ module.exports = function (params) {
             }
 
         }
-
         return Promise.all(promises).then(values => {
             return callback(null, null);
-        });
+        }).catch(function(error) {
+            // prevent stream unhandled exception from being suppressed by Promise
+           callback(new PluginError('gulp-d3r-bundle', error));
+        })
     });
+
 };


### PR DESCRIPTION
```
(node:6535) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:6535) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```